### PR TITLE
chore(pull-request-template): rename description section

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,7 @@
 ## Contexto
 
-## Descripción
+## Solución técnica
+_(tip: listar los cambios que tiene el PR)_
 
 ## Tarea o ticket relacionado
 


### PR DESCRIPTION
## Contexto
Hace un mes empezamos agregamos un template para el pull request. Nos hemos dado cuenta que el título de la sección "Descripción" es un poco confusa, por que vamos a cambiarla por "Solución técnica".

## Descripción
- Se cambia el título de la sección
- Se agrega un tip para la sección renombrada, que debería impulsar describir los cambios con un listado