### PR TITLE
logo update

### DIFF
--- a/assets/js/ventipay_checkout.js
+++ b/assets/js/ventipay_checkout.js
@@ -18,10 +18,6 @@ const Label = () => (
       'img',
       {
         src: settings.icon,
-        style: {
-          height: '70px',
-          width: '70px'
-        }
       },
       null
     )

--- a/includes/class-wc-gateway-ventipay.php
+++ b/includes/class-wc-gateway-ventipay.php
@@ -16,7 +16,7 @@ class WC_Gateway_VentiPay extends WC_Payment_Gateway
   public function __construct()
   {
     $this->id = 'ventipay';
-    $this->icon = 'https://ventipay.com/assets/apps/woocommerce/plugin-woocommerce-icon-checkout.png';
+    $this->icon = 'https://ventipay.com/assets/apps/woocommerce/plugin-woocommerce-icon-checkout_new.png';
     $this->has_fields = false;
     $this->method_title = __('VentiPay', 'ventipay');
     $this->method_description = __(

--- a/includes/class-wc-gateway-ventipay.php
+++ b/includes/class-wc-gateway-ventipay.php
@@ -16,7 +16,7 @@ class WC_Gateway_VentiPay extends WC_Payment_Gateway
   public function __construct()
   {
     $this->id = 'ventipay';
-    $this->icon = 'https://ventipay.com/assets/apps/woocommerce/plugin-woocommerce-icon-checkout-new.png';
+    $this->icon = 'https://ventipay.com/assets/apps/woocommerce/plugin-woocommerce-icon-checkout.png';
     $this->has_fields = false;
     $this->method_title = __('VentiPay', 'ventipay');
     $this->method_description = __(

--- a/includes/class-wc-gateway-ventipay.php
+++ b/includes/class-wc-gateway-ventipay.php
@@ -16,7 +16,7 @@ class WC_Gateway_VentiPay extends WC_Payment_Gateway
   public function __construct()
   {
     $this->id = 'ventipay';
-    $this->icon = 'https://ventipay.com/assets/apps/woocommerce/plugin-woocommerce-icon-checkout_new.png';
+    $this->icon = 'https://ventipay.com/assets/apps/woocommerce/plugin-woocommerce-icon-checkout-new.png';
     $this->has_fields = false;
     $this->method_title = __('VentiPay', 'ventipay');
     $this->method_description = __(


### PR DESCRIPTION
## Contexto
Se está visualizando el logo antiguo de ventipay en los métodos de pago de woocommerce

## Solución Técnica
Se actualizo el logo con una nueva url y se removió el height y width de la imagen de los styles debido que tendría sentido que el tamaño sea a partir de la imagen real

## Tarea o ticket relacionado
[Ticket](https://www.notion.so/ventipay/Widget-con-logo-de-venti-desactualizado-199a5cef718c80209f2bd54c8c4a0831?pvs=4)

## QA: screenshots, recordings de pantalla