### PR TITLE
Adjust the fixed size and position of the Venti logo at checkout.

### DIFF
--- a/assets/js/ventipay_checkout.js
+++ b/assets/js/ventipay_checkout.js
@@ -18,6 +18,13 @@ const Label = () => (
       'img',
       {
         src: settings.icon,
+        style: {
+          width: '70px',         
+          height: 'auto',        
+          maxHeight: '28px',  
+          objectFit: 'contain',
+          flexShrink: 0          
+        }
       },
       null
     )


### PR DESCRIPTION
## Contexto

Se actualizó el componente del método de pago Venti en el checkout para corregir problemas de visualización del logo en distintos temas y tamaños de pantalla. 

Para solucionarlo, se aplicaron estilos directamente al elemento <img> que contiene el logo, con el objetivo de fijar su tamaño, mantener su proporción y asegurar su correcta visualización en todos los casos.


## Descripción

Estilos aplicados al logo y su propósito:

**width: '70px'**: Define un ancho fijo.

**height: 'auto'**: Permite que la altura se ajuste automáticamente para mantener la proporción original del logo.

**maxHeight: '28px'**: Limita la altura para evitar que el logo se vea demasiado grande en pantallas amplias.

**objectFit: 'contain'**: Evita que el logo se deforme o se recorte.

**flexShrink: 0**:  No se achica en responsive.

## Tarea o ticket relacionado

https://www.notion.so/ventipay/Mejorar-visualizaci-n-de-logo-venti-en-woocommerce-246a5cef718c80688720d3aeb0fad530

## QA: screenshots, recordings de pantalla


https://github.com/user-attachments/assets/4a2415a6-953f-4eff-8bfa-f640af95a5ee

