### PR TITLE
logo to isotype and apply styles

### DIFF
--- a/assets/js/ventipay_checkout.js
+++ b/assets/js/ventipay_checkout.js
@@ -18,12 +18,22 @@ const Label = () => (
       'img',
       {
         src: settings.icon,
-        style: {
-         height: '45px',
-          width: 'auto',
-          maxHeight: 'none',
-          flexShrink: 0
-        }
+        ref: (el) => {
+          if (el) {
+            el.setAttribute(
+              'style',
+              ` height: 45px !important;
+                width: 45px !important;
+                max-height: none !important;
+                max-width: 100% !important;
+                vertical-align: middle !important;
+                background-repeat: no-repeat !important;
+                background-size: cover !important;
+                shape-margin: 1rem !important;
+              `
+            )
+          }
+        },
       },
       null
     )

--- a/assets/js/ventipay_checkout.js
+++ b/assets/js/ventipay_checkout.js
@@ -19,11 +19,10 @@ const Label = () => (
       {
         src: settings.icon,
         style: {
-          width: '70px',         
-          height: 'auto',        
-          maxHeight: '28px',  
-          objectFit: 'contain',
-          flexShrink: 0          
+         height: '45px',
+          width: 'auto',
+          maxHeight: 'none',
+          flexShrink: 0
         }
       },
       null

--- a/includes/class-wc-gateway-ventipay.php
+++ b/includes/class-wc-gateway-ventipay.php
@@ -16,7 +16,7 @@ class WC_Gateway_VentiPay extends WC_Payment_Gateway
   public function __construct()
   {
     $this->id = 'ventipay';
-    $this->icon = 'https://ventipay.com/assets/apps/woocommerce/plugin-woocommerce-icon-checkout.png';
+    $this->icon = 'https://ventipay.com/assets/apps/woocommerce/venti-icon.svg';
     $this->has_fields = false;
     $this->method_title = __('Venti', 'ventipay');
     $this->method_description = __(


### PR DESCRIPTION
## Contexto

Algunos temas de cada comercio cambia el estilo de el logo de Venti, para asegurar consistencia visual, reemplazo el logo anterior por el isotipo de Venti y aplico estilos mínimos que evitan distorsión.

## Solución técnica

Llamar la nueva imagen (isotipo) y aplicar estilos.

_(tip: listar los cambios que tiene el PR)_

height: 45px  fija la altura del logo

width: auto mantiene la proporción original

maxHeight: none  elimina límites impuestos por el tema

flexShrink: 0  evita que se reduzca dentro de contenedores flex

## Tarea o ticket relacionado

https://www.notion.so/ventipay/Logo-de-woocommerce-255a5cef718c802fb0aae72733ca9b6e

## QA: screenshots, recordings de pantalla

<img width="971" height="259" alt="image" src="https://github.com/user-attachments/assets/247507a3-fca6-46d3-a42e-f09c1ae5374b" />
